### PR TITLE
Add capability to import and use previously generated excel as template

### DIFF
--- a/lib/screens/3_GeneratePage/generator_history.dart
+++ b/lib/screens/3_GeneratePage/generator_history.dart
@@ -9,7 +9,8 @@ import 'package:path_provider/path_provider.dart';
 /// `GeneratorHistory` is a StatefulWidget that displays a history of generated files.
 /// It watches for changes in the output directory and updates the UI accordingly.
 class GeneratorHistory extends StatefulWidget {
-  const GeneratorHistory({super.key});
+  final Function(File) onFileImported;
+  const GeneratorHistory({super.key, required this.onFileImported});
 
   @override
   State<GeneratorHistory> createState() => _GeneratorHistoryState();
@@ -191,10 +192,12 @@ class _GeneratorHistoryState extends State<GeneratorHistory> with TickerProvider
                   tooltip: "Open",
                   onPressed: () => OpenFile.open(file.path),
                 ),
-                ElevatedButton.icon(
-                  icon: const Icon(Icons.arrow_circle_right_outlined),
+                ActionChip(
+                  avatar: const Icon(Icons.arrow_circle_right_outlined),
                   label: const Text("Import"),
-                  onPressed: () {},
+                  onPressed: () => widget.onFileImported(file),
+                  backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
+                  tooltip: "Import this file so that it can be used as a template.\nImporting lets you generate a new file with the data in this file as a base.",
                 ),
               ],
             ),

--- a/lib/utils/excel_writer.dart
+++ b/lib/utils/excel_writer.dart
@@ -8,6 +8,7 @@ import 'package:path_provider/path_provider.dart';
 import '../models/cell_mapping.dart';
 import '../utils/utils.dart';
 
+/// This class holds the logic for writing data to an excel file.
 class ExcelWriter {
   final CellMapping cm = CellMapping("ExcelWriter");
 
@@ -15,13 +16,16 @@ class ExcelWriter {
   /// 
   /// - It uses `github.com/jeryjs/excel-writer` for writing data to the excel file.
   /// 
-  /// It returns a stream that can be used to display the progress of the operation.
+  /// It can accept a [inputFile] if a previously created excel file is to be used as a template.
+  /// If no file is passed or the file is null, it will be created using the default template.
+  /// 
+  /// It returns a [Stream] that can be used to display the progress of the operation.
   /// Once successfully written to excel, it launches the file using the default app.
-  Stream<String> writeToExcel() async* {
+  Stream<String> writeToExcel(File? inputFile) async* {
     final appDir = await getApplicationSupportDirectory();
 
     // Load the Excel files
-    final inputFile = await getFileFromAssets('assets/input.xlsx');
+    inputFile ??= await getFileFromAssets('assets/input.xlsx');
     final outputName = '${cm.courseCode}/${getFormattedDate(DateTime.now())}';
     final outputFile = File('${appDir.path}/output/$outputName.xlsx');
     outputFile.create(exclusive: true, recursive: true);


### PR DESCRIPTION
This pull request adds the capability to import and use a previously generated excel file as a template for generating new files. It introduces a new parameter `inputFile` to the `writeToExcel` method in the `ExcelWriter` class, which allows the user to pass a file to be used as a template. If no file is passed or the file is null, the default template will be used. Additionally, this pull request includes changes to the `GeneratorHistory` widget, adding an "Import" action chip that allows the user to import a file and use it as a template for generating new files.