### PR TITLE
Add support for JPEG files in qpAnalyser

### DIFF
--- a/lib/screens/1_DetailsPage/qp_analyser.dart
+++ b/lib/screens/1_DetailsPage/qp_analyser.dart
@@ -35,7 +35,7 @@ class _QpAnalyserState extends State<QpAnalyser> {
     FilePickerResult? result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
       allowMultiple: true,
-      allowedExtensions: ['jpg', 'png', 'webp', 'heic', 'heif'],
+      allowedExtensions: ['jpg', 'jpeg', 'png', 'webp', 'heic', 'heif'],
     );
 
     if (result != null) {


### PR DESCRIPTION
This pull request adds support for JPEG files in the qpAnalyser component. Previously, only JPG, PNG, WebP, HEIC, and HEIF files were supported. With this change, JPEG files can also be selected and analyzed.