### PR TITLE
Update weightage calculation formula

### DIFF
--- a/lib/screens/2_WeightagePage/weightage_screen.dart
+++ b/lib/screens/2_WeightagePage/weightage_screen.dart
@@ -72,9 +72,9 @@ class _WeightagePageState extends State<WeightagePage> {
     super.initState();
     _restoreControllers();
 
-    /// Set ctrl[1-6]'s value to always be 1/3 of the co target (ctrl[0])
+    /// Set ctrl[1-6]'s value to always be 3/100 * coTarget (ctrl[0])
     ctrl[0].addListener(() {
-      double value = double.tryParse(ctrl[0].text)! / 3;
+      double value = double.tryParse(ctrl[0].text)! * 3 / 100;
       for (int i = 1; i <= 6; i++) {
         ctrl[i].text = value.toStringAsFixed(2);
       }


### PR DESCRIPTION
This pull request updates the weightage calculation formula in the weightage_screen.dart file. The formula now sets ctrl[1-6]'s value to be 3/100 * coTarget (ctrl[0]) instead of 1/3 of the co target. This change ensures more accurate weightage calculations.