### PR TITLE
Fix bug in switching to generate page

### DIFF
--- a/lib/screens/3_GeneratePage/generate_screen.dart
+++ b/lib/screens/3_GeneratePage/generate_screen.dart
@@ -33,9 +33,6 @@ class _GeneratePageState extends State<GeneratePage> {
   /// The file that is imported by the user.
   File? importedFile;
 
-  /// Operations generated for the current page.
-  final operations = CellMapping("GeneratePage").generateOperations();
-
   /// Describes the part of the user interface represented by this widget.
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This pull request fixes a bug in the code that handles switching to the generate page. The bug caused the operations to be generated multiple times, which resulted in incorrect behavior. The fix removes the unnecessary generation of operations for the current page.