### PR TITLE
Fix navigation bug in DetailsPage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -216,13 +216,9 @@ class _MainAppState extends State<MainApp> {
 							style: fluentUiBtn(context),
 							onPressed: index < pages.length - 1
 								? () {
-									if (currentPage().isFilled()) {
-										if (index == 2) {
-											setState(() => index = 0);
-										} else {
-											setState(() => ++index);
-										}
-									}
+                    if (currentPage().isFilled()) {
+                      setState(() => ++index);
+                    }
 									}
 								: null,
 							child: const Icon(Icons.arrow_forward_ios),

--- a/lib/screens/1_DetailsPage/details_screen.dart
+++ b/lib/screens/1_DetailsPage/details_screen.dart
@@ -73,6 +73,14 @@ class _DetailsPageState extends State<DetailsPage> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
+    });
+  }
+
+  @override
   void deactivate() {
     CellMapping("StartPage").setComponentsMapping(components);
     _scrollController.dispose();

--- a/lib/screens/1_DetailsPage/get_component.dart
+++ b/lib/screens/1_DetailsPage/get_component.dart
@@ -24,7 +24,7 @@ class GetComponent extends StatefulWidget {
   State<GetComponent> createState() => _GetComponentState();
 }
 
-class _GetComponentState extends State<GetComponent> {
+class _GetComponentState extends State<GetComponent> with AutomaticKeepAliveClientMixin {
   get formKey => widget.formKey;
   List<TextEditingController> get ctrl => widget.controllers;
   get index => widget.index;
@@ -53,8 +53,7 @@ class _GetComponentState extends State<GetComponent> {
   Future<void> _saveControllers() async {
     final prefs = await SharedPreferences.getInstance();
     for (int i = 0; i < ctrl.length; i++) {
-      await prefs.setString(
-          'get_component_${index}_controller$i', ctrl[i].text);
+      await prefs.setString('get_component_${index}_controller$i', ctrl[i].text);
     }
   }
 
@@ -86,6 +85,7 @@ class _GetComponentState extends State<GetComponent> {
   /// The QPAnalyser is disabled for all components except IA.
   @override
   Widget build(BuildContext ctx) {
+    super.build(ctx);
     var isCT = ctrl[0].text != "IA";
     return FocusTraversalGroup(
       child: Card(
@@ -151,4 +151,7 @@ class _GetComponentState extends State<GetComponent> {
       ),
     );
   }
+  
+  @override
+  bool get wantKeepAlive => true;
 }


### PR DESCRIPTION
This pull request fixes a navigation bug in the DetailsPage component. The bug caused the page to not navigate to the next page when the current page is filled. The bug has been fixed by updating the onPressed function in the MainApp class. Additionally, the initState function in the DetailsPageState class has been updated to scroll to the bottom of the page after it is built. The _GetComponentState class in the get_component.dart file has been updated to include the AutomaticKeepAliveClientMixin and the wantKeepAlive getter method to ensure that the state is kept alive when switching between components.